### PR TITLE
Adding db and dbport cli args, and cleaning up messages

### DIFF
--- a/sibyl/cli.py
+++ b/sibyl/cli.py
@@ -22,10 +22,18 @@ def get_parser():
         help="Be verbose. Use -vv for increased verbosity.",
     )
 
-    common.add_argument("--docker", action="store_true", help="deployed in docker environment")
-    common.add_argument("--dbhost", action="store", help="deployed in docker environment")
+    common.add_argument("--docker", action="store_true", help="Deploy in docker environment")
+    common.add_argument(
+        "--dbhost", action="store", help="Host address to access database. Overrides config"
+    )
+    common.add_argument(
+        "--dbport", action="store", help="Port to access database. Overrides config"
+    )
+    common.add_argument(
+        "-D", "--db", action="store", help="Database name to use. Overrides config"
+    )
 
-    parser = argparse.ArgumentParser(description="sibyl Command Line Interface.")
+    parser = argparse.ArgumentParser(description="Sibyl Command Line Interface.")
     parser.set_defaults(function=None)
 
     # sibyl [action]
@@ -54,6 +62,6 @@ def main():
 
     setup_logging(args.verbose, args.logfile)
     config = read_config("./sibyl/config.yml")
-    sibyl = Sibyl(config, args.docker, args.dbhost)
+    sibyl = Sibyl(config, args.docker, args.dbhost, args.dbport, args.db)
 
     args.function(sibyl, args)

--- a/sibyl/core.py
+++ b/sibyl/core.py
@@ -55,22 +55,28 @@ class Sibyl:
 
         return app
 
-    def __init__(self, conf: dict, docker: bool, dbhost=None):
+    def __init__(self, conf: dict, docker: bool, dbhost=None, dbport=None, db=None):
         self._conf = conf.copy()
 
         if not docker:
             kargs = {
                 key: conf["mongodb"][key] for key in ["db", "host", "port", "username", "password"]
             }
-            if dbhost is not None:
-                kargs["host"] = dbhost
-            self._db = connect(**kargs)
         else:
             kargs = {
                 key: conf["docker"]["mongodb"][key]
                 for key in ["db", "host", "port", "username", "password"]
             }
-            self._db = connect(**kargs)
+        if dbhost is not None:
+            kargs["host"] = dbhost
+        if dbport is not None:
+            if not dbport.isdigit():
+                LOGGER.exception("dbport is not a valid integer")
+                raise ValueError
+            kargs["port"] = int(dbport)
+        if db is not None:
+            kargs["db"] = db
+        self._db = connect(**kargs)
         # TODO - using testing datasets in test env
 
     def run_server(self, env=None, port=None):


### PR DESCRIPTION
### Closing issues

Closes #52 

### Description

The sibyl run command can now take a database name (using the `--db` or `-D` tags), which will override anything given in config. This should make testing with multiple databases faster and easier.

Also adding a few extra CLI related fixes to this PR:
- Adding a `dbport` arg, for consistency with the `dbhost` arg.
- Fixing some help text
- Allowing CLI args to work with docker builds as well

### Test Plan

Tested all new CLIs with multiple databases/port options to ensure correctness

