### PR TITLE
Updating API calls to use dict instead of JSON strings

### DIFF
--- a/sibyl/resources/computing.py
+++ b/sibyl/resources/computing.py
@@ -525,6 +525,7 @@ class SimilarEntities(Resource):
         similar_entities = explainer.produce_similar_examples(
             entities, x_train_orig=X, y_train=y, standardize=True
         )
+
         for eid in similar_entities:
             similar_entities[eid]["X"] = similar_entities[eid]["X"].to_dict(orient="index")
             similar_entities[eid]["y"] = similar_entities[eid]["y"].to_dict()

--- a/sibyl/resources/computing.py
+++ b/sibyl/resources/computing.py
@@ -385,7 +385,7 @@ class MultiFeatureContributions(Resource):
 
         contributions = explainer.produce_feature_contributions(entities)
         contributions_json = {
-            eid: contributions[eid].set_index("Feature Name").to_json(orient="index")
+            eid: contributions[eid].set_index("Feature Name").to_dict(orient="index")
             for eid in contributions
         }
 
@@ -526,8 +526,8 @@ class SimilarEntities(Resource):
             entities, x_train_orig=X, y_train=y, standardize=True
         )
         for eid in similar_entities:
-            similar_entities[eid]["X"] = similar_entities[eid]["X"].to_json(orient="index")
-            similar_entities[eid]["y"] = similar_entities[eid]["y"].to_json(orient="index")
-            similar_entities[eid]["Input"] = similar_entities[eid]["Input"].to_json(orient="index")
+            similar_entities[eid]["X"] = similar_entities[eid]["X"].to_dict(orient="index")
+            similar_entities[eid]["y"] = similar_entities[eid]["y"].to_dict()
+            similar_entities[eid]["Input"] = similar_entities[eid]["Input"].to_dict()
 
         return {"similar_entities": similar_entities}, 200

--- a/sibyl/test_apis_on_database.ipynb
+++ b/sibyl/test_apis_on_database.ipynb
@@ -6,8 +6,8 @@
    "metadata": {
     "collapsed": true,
     "ExecuteTime": {
-     "end_time": "2023-09-06T19:39:37.303199600Z",
-     "start_time": "2023-09-06T19:39:37.288656400Z"
+     "end_time": "2023-09-07T14:22:20.912654100Z",
+     "start_time": "2023-09-07T14:22:20.904757200Z"
     }
    },
    "outputs": [],
@@ -25,8 +25,8 @@
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2023-09-06T19:39:37.319152100Z",
-     "start_time": "2023-09-06T19:39:37.304117800Z"
+     "end_time": "2023-09-07T14:22:20.912654100Z",
+     "start_time": "2023-09-07T14:22:20.906276600Z"
     }
    },
    "outputs": [],
@@ -43,8 +43,8 @@
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2023-09-06T19:39:37.350647700Z",
-     "start_time": "2023-09-06T19:39:37.319152100Z"
+     "end_time": "2023-09-07T14:22:20.930386400Z",
+     "start_time": "2023-09-07T14:22:20.912654100Z"
     }
    },
    "outputs": [],
@@ -76,8 +76,8 @@
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2023-09-06T19:39:37.538650700Z",
-     "start_time": "2023-09-06T19:39:37.354644500Z"
+     "end_time": "2023-09-07T14:22:21.127572700Z",
+     "start_time": "2023-09-07T14:22:20.929064100Z"
     }
    },
    "outputs": [
@@ -119,8 +119,8 @@
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2023-09-06T19:39:37.587732100Z",
-     "start_time": "2023-09-06T19:39:37.540650900Z"
+     "end_time": "2023-09-07T14:22:21.191458500Z",
+     "start_time": "2023-09-07T14:22:21.126572200Z"
     }
    },
    "outputs": [
@@ -163,8 +163,8 @@
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2023-09-06T19:39:37.661991900Z",
-     "start_time": "2023-09-06T19:39:37.584526800Z"
+     "end_time": "2023-09-07T14:22:21.244074200Z",
+     "start_time": "2023-09-07T14:22:21.163850300Z"
     }
    },
    "outputs": [
@@ -173,9 +173,9 @@
      "output_type": "stream",
      "text": [
       "Number of models: 1\n",
-      "Sample model: {'id': '64f8d56cb15bf0bb27c103ea', 'name': 'placeholder', 'description': 'placeholder', 'performance': 'placeholder'}\n",
-      "Sample importance ('MSSubClass', 1783.8738895418035)\n",
-      "Sample prediction: {'output': 136805.84817939159}\n"
+      "Sample model: {'id': '64f9cd5fb78f7227c43d3660', 'name': 'placeholder', 'description': 'placeholder', 'performance': 'placeholder'}\n",
+      "Sample importance ('MSSubClass', 1783.8738895418905)\n",
+      "Sample prediction: {'output': 136805.84817939164}\n"
      ]
     }
    ],
@@ -208,8 +208,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-09-06T19:39:37.706442700Z",
-     "start_time": "2023-09-06T19:39:37.662992300Z"
+     "end_time": "2023-09-07T14:22:21.250749Z",
+     "start_time": "2023-09-07T14:22:21.242076200Z"
     }
    },
    "outputs": [
@@ -217,7 +217,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sample context: {'context': {'id': '64f8d567b15bf0bb27c0fe38', 'terms': {'Positive': 'Beneficial', 'Negative': 'Detrimental', 'Feature': 'Factor', 'Prediction': 'Predicted Price', 'Feature Contributions': 'Factor Contributions', 'Counterfactuals': 'Sandbox', 'Feature Importance': 'Factor Importance', 'Feature Distributions': 'Factor Distributions', 'Entity': 'House'}, 'gui_preset': 'profit_usd', 'gui_config': {'pred_type': 'numeric', 'model_pred_bad_outcome': False, 'pred_format_string': '${:,.2f}'}}}\n"
+      "Sample context: {'context': {'id': '64f9cd5ab78f7227c43d30ae', 'terms': {'Positive': 'Beneficial', 'Negative': 'Detrimental', 'Feature': 'Factor', 'Prediction': 'Predicted Price', 'Feature Contributions': 'Factor Contributions', 'Counterfactuals': 'Sandbox', 'Feature Importance': 'Factor Importance', 'Feature Distributions': 'Factor Distributions', 'Entity': 'House'}, 'gui_preset': 'profit_usd', 'gui_config': {'pred_type': 'numeric', 'model_pred_bad_outcome': False, 'pred_format_string': '${:,.2f}'}}}\n"
      ]
     }
    ],
@@ -242,8 +242,8 @@
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2023-09-06T19:39:37.943459200Z",
-     "start_time": "2023-09-06T19:39:37.683182400Z"
+     "end_time": "2023-09-07T14:22:21.498985300Z",
+     "start_time": "2023-09-07T14:22:21.251747500Z"
     }
    },
    "outputs": [
@@ -251,10 +251,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sample contribution ('MSSubClass', 1719.226755355572)\n",
+      "Sample contribution ('MSSubClass', 1719.226755355656)\n",
       "Multi-contributions validated\n",
-      "Sample modified prediction: {'prediction': 183246.9701684981}\n",
-      "Sample predictions: [['MSSubClass', 183246.9701684981], ['MSZoning', 183246.9701684981]]\n"
+      "Sample modified prediction: {'prediction': 183246.97016849724}\n",
+      "Sample predictions: [['MSSubClass', 183246.97016849724], ['MSZoning', 183246.97016849724]]\n"
      ]
     }
    ],
@@ -272,7 +272,7 @@
     "assert \"contributions\" in response.json\n",
     "for eid in response.json[\"contributions\"]:\n",
     "    try:\n",
-    "        pd.read_json(response.json[\"contributions\"][eid], orient=\"index\")\n",
+    "        pd.DataFrame.from_dict(response.json[\"contributions\"][eid], orient=\"index\")\n",
     "    except Exception:\n",
     "        print(\"Error with multi-contributions - wrong format\")\n",
     "print(\"Multi-contributions validated\")\n",
@@ -309,8 +309,8 @@
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2023-09-06T19:39:38.318884300Z",
-     "start_time": "2023-09-06T19:39:37.945910900Z"
+     "end_time": "2023-09-07T14:22:21.938270800Z",
+     "start_time": "2023-09-07T14:22:21.500990900Z"
     }
    },
    "outputs": [
@@ -332,14 +332,14 @@
       "Name: Feature Value, Length: 79, dtype: object\n",
       "Sample similar entity:\n",
       "      MSSubClass MSZoning  LotFrontage  LotArea Street  Alley LotShape  \\\n",
-      "0            20       RL           75     9937   Pave    NaN      Reg   \n",
-      "202          20       RL           75    10125   Pave    NaN      Reg   \n",
-      "562          20       RL           77    10010   Pave    NaN      Reg   \n",
+      "0            20       RL         75.0     9937   Pave    NaN      Reg   \n",
+      "202          20       RL         75.0    10125   Pave    NaN      Reg   \n",
+      "562          20       RL         77.0    10010   Pave    NaN      Reg   \n",
       "\n",
       "    LandContour Utilities LotConfig  ... ScreenPorch PoolArea PoolQC  Fence  \\\n",
-      "0           Lvl    AllPub    Inside  ...           0        0    NaN   None   \n",
+      "0           Lvl    AllPub    Inside  ...           0        0    NaN    NaN   \n",
       "202         Lvl    AllPub    Inside  ...           0        0    NaN  MnPrv   \n",
-      "562         Lvl    AllPub    Inside  ...           0        0    NaN   None   \n",
+      "562         Lvl    AllPub    Inside  ...           0        0    NaN    NaN   \n",
       "\n",
       "    MiscFeature MiscVal  MoSold  YrSold  SaleType  SaleCondition  \n",
       "0           NaN       0       6    2008        WD         Normal  \n",
@@ -347,10 +347,16 @@
       "562         NaN       0       4    2006        WD         Normal  \n",
       "\n",
       "[3 rows x 79 columns]\n",
-      "          0\n",
-      "0    147500\n",
-      "202  171500\n",
-      "562  170000\n"
+      "0      147500\n",
+      "202    171500\n",
+      "562    170000\n",
+      "dtype: int64\n",
+      "MSSubClass       20\n",
+      "MSZoning         RL\n",
+      "LotFrontage    75.0\n",
+      "LotArea        9937\n",
+      "Street         Pave\n",
+      "dtype: object\n"
      ]
     }
    ],
@@ -375,19 +381,27 @@
     "for eid in response.json[\"similar_entities\"]:\n",
     "    assert \"X\" in response.json[\"similar_entities\"][eid]\n",
     "    try:\n",
-    "        X = pd.read_json(response.json[\"similar_entities\"][eid][\"X\"], orient=\"index\").head()\n",
+    "        X = pd.DataFrame.from_dict(\n",
+    "            response.json[\"similar_entities\"][eid][\"X\"], orient=\"index\"\n",
+    "        ).head()\n",
     "        if print_flag:\n",
     "            print(\"Sample similar entity:\\n\", X)\n",
     "    except Exception:\n",
     "        print(\"Error with similar entities - wrong X format\")\n",
     "    assert \"y\" in response.json[\"similar_entities\"][eid]\n",
     "    try:\n",
-    "        y = pd.read_json(response.json[\"similar_entities\"][eid][\"y\"], orient=\"index\").head()\n",
+    "        y = pd.Series(response.json[\"similar_entities\"][eid][\"y\"]).head()\n",
     "        if print_flag:\n",
     "            print(y)\n",
+    "    except Exception:\n",
+    "        print(\"Error with similar entities - wrong y format\")\n",
+    "    try:\n",
+    "        input = pd.Series(response.json[\"similar_entities\"][eid][\"Input\"]).head()\n",
+    "        if print_flag:\n",
+    "            print(input)\n",
     "            print_flag = False\n",
     "    except Exception:\n",
-    "        print(\"Error with similar entities - wrong y format\")"
+    "        print(\"Error with similar entities - wrong input format\")"
    ]
   },
   {
@@ -398,8 +412,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-09-06T19:39:38.336955400Z",
-     "start_time": "2023-09-06T19:39:38.317884400Z"
+     "end_time": "2023-09-07T14:22:21.938270800Z",
+     "start_time": "2023-09-07T14:22:21.935853200Z"
     }
    }
   }

--- a/sibyl/test_apis_on_database.ipynb
+++ b/sibyl/test_apis_on_database.ipynb
@@ -2,12 +2,12 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "metadata": {
     "collapsed": true,
     "ExecuteTime": {
-     "end_time": "2023-09-07T14:22:20.912654100Z",
-     "start_time": "2023-09-07T14:22:20.904757200Z"
+     "end_time": "2023-09-07T14:42:46.544868200Z",
+     "start_time": "2023-09-07T14:42:46.537656700Z"
     }
    },
    "outputs": [],
@@ -18,15 +18,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2023-09-07T14:22:20.912654100Z",
-     "start_time": "2023-09-07T14:22:20.906276600Z"
+     "end_time": "2023-09-07T14:42:46.555893700Z",
+     "start_time": "2023-09-07T14:42:46.540618100Z"
     }
    },
    "outputs": [],
@@ -36,15 +36,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2023-09-07T14:22:20.930386400Z",
-     "start_time": "2023-09-07T14:22:20.912654100Z"
+     "end_time": "2023-09-07T14:42:46.566680Z",
+     "start_time": "2023-09-07T14:42:46.546380900Z"
     }
    },
    "outputs": [],
@@ -69,15 +69,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2023-09-07T14:22:21.127572700Z",
-     "start_time": "2023-09-07T14:22:20.929064100Z"
+     "end_time": "2023-09-07T14:42:46.866155400Z",
+     "start_time": "2023-09-07T14:42:46.569192400Z"
     }
    },
    "outputs": [
@@ -112,15 +112,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2023-09-07T14:22:21.191458500Z",
-     "start_time": "2023-09-07T14:22:21.126572200Z"
+     "end_time": "2023-09-07T14:42:46.923158800Z",
+     "start_time": "2023-09-07T14:42:46.866155400Z"
     }
    },
    "outputs": [
@@ -156,15 +156,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2023-09-07T14:22:21.244074200Z",
-     "start_time": "2023-09-07T14:22:21.163850300Z"
+     "end_time": "2023-09-07T14:42:46.984771500Z",
+     "start_time": "2023-09-07T14:42:46.901371900Z"
     }
    },
    "outputs": [
@@ -204,12 +204,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 19,
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-09-07T14:22:21.250749Z",
-     "start_time": "2023-09-07T14:22:21.242076200Z"
+     "end_time": "2023-09-07T14:42:46.985772100Z",
+     "start_time": "2023-09-07T14:42:46.957705100Z"
     }
    },
    "outputs": [
@@ -235,15 +235,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 20,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2023-09-07T14:22:21.498985300Z",
-     "start_time": "2023-09-07T14:22:21.251747500Z"
+     "end_time": "2023-09-07T14:42:47.195580500Z",
+     "start_time": "2023-09-07T14:42:46.965631800Z"
     }
    },
    "outputs": [
@@ -273,8 +273,9 @@
     "for eid in response.json[\"contributions\"]:\n",
     "    try:\n",
     "        pd.DataFrame.from_dict(response.json[\"contributions\"][eid], orient=\"index\")\n",
-    "    except Exception:\n",
+    "    except Exception as e:\n",
     "        print(\"Error with multi-contributions - wrong format\")\n",
+    "        raise e\n",
     "print(\"Multi-contributions validated\")\n",
     "\n",
     "row_ids = list(sample_entity[\"features\"].keys())\n",
@@ -302,15 +303,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 21,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     },
     "ExecuteTime": {
-     "end_time": "2023-09-07T14:22:21.938270800Z",
-     "start_time": "2023-09-07T14:22:21.500990900Z"
+     "end_time": "2023-09-07T14:42:47.558574800Z",
+     "start_time": "2023-09-07T14:42:47.199088800Z"
     }
    },
    "outputs": [
@@ -318,7 +319,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sample contribution object: MSSubClass           20\n",
+      "Sample contribution object:\n",
+      " MSSubClass           20\n",
       "LotFrontage        80.0\n",
       "LotArea            9600\n",
       "OverallQual           6\n",
@@ -347,11 +349,13 @@
       "562         NaN       0       4    2006        WD         Normal  \n",
       "\n",
       "[3 rows x 79 columns]\n",
-      "0      147500\n",
+      "y:\n",
+      " 0      147500\n",
       "202    171500\n",
       "562    170000\n",
       "dtype: int64\n",
-      "MSSubClass       20\n",
+      "Input row:\n",
+      " MSSubClass       20\n",
       "MSZoning         RL\n",
       "LotFrontage    75.0\n",
       "LotArea        9937\n",
@@ -370,9 +374,10 @@
     "assert \"contribution\" in response.json\n",
     "try:\n",
     "    df = pd.read_json(response.json[\"contribution\"], orient=\"index\")\n",
-    "    print(\"Sample contribution object:\", df[df.columns[0]])\n",
-    "except Exception:\n",
+    "    print(\"Sample contribution object:\\n\", df[df.columns[0]])\n",
+    "except Exception as e:\n",
     "    print(\"Error with modified-contributions - wrong format\")\n",
+    "    raise e\n",
     "\n",
     "response = client.post(\"/api/v1/similar_entities/\", json={\"eids\": eids, \"model_id\": model_id})\n",
     "assert response.status_code == 200\n",
@@ -386,34 +391,37 @@
     "        ).head()\n",
     "        if print_flag:\n",
     "            print(\"Sample similar entity:\\n\", X)\n",
-    "    except Exception:\n",
+    "    except Exception as e:\n",
     "        print(\"Error with similar entities - wrong X format\")\n",
+    "        raise e\n",
     "    assert \"y\" in response.json[\"similar_entities\"][eid]\n",
     "    try:\n",
     "        y = pd.Series(response.json[\"similar_entities\"][eid][\"y\"]).head()\n",
     "        if print_flag:\n",
-    "            print(y)\n",
-    "    except Exception:\n",
+    "            print(\"y:\\n\", y)\n",
+    "    except Exception as e:\n",
     "        print(\"Error with similar entities - wrong y format\")\n",
+    "        raise e\n",
     "    try:\n",
     "        input = pd.Series(response.json[\"similar_entities\"][eid][\"Input\"]).head()\n",
     "        if print_flag:\n",
-    "            print(input)\n",
+    "            print(\"Input row:\\n\", input)\n",
     "            print_flag = False\n",
-    "    except Exception:\n",
-    "        print(\"Error with similar entities - wrong input format\")"
+    "    except Exception as e:\n",
+    "        print(\"Error with similar entities - wrong input format\")\n",
+    "        raise e"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 21,
    "outputs": [],
    "source": [],
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-09-07T14:22:21.938270800Z",
-     "start_time": "2023-09-07T14:22:21.935853200Z"
+     "end_time": "2023-09-07T14:42:47.559580100Z",
+     "start_time": "2023-09-07T14:42:47.557069400Z"
     }
    }
   }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -183,7 +183,7 @@ def entities():
             "eid": "ent2",
             "row_ids": ["row_a"],
             "property": {"group_ids": ["101"]},
-            "features": {"row_a": features1_b, "row_b": features1_b},
+            "features": {"row_a": features1_b, "row_b": features2_b},
             "labels": {"row_a": 2, "row_b": 2},
         },
         {

--- a/tests/test_computing.py
+++ b/tests/test_computing.py
@@ -180,10 +180,11 @@ def test_post_similar_entities(client, models, entities, multirow_entities):
     ).json
     similar_entities = response["similar_entities"]
 
-    for eid in [entity["eid"] for entity in entities]:  # Assert no error
-        pd.DataFrame.from_dict(similar_entities[eid]["X"], orient="index")
-        pd.Series(similar_entities[eid]["y"])
-        pd.Series(similar_entities[eid]["Input"])
+    for i, eid in enumerate([entity["eid"] for entity in entities]):
+        assert next(iter(similar_entities[eid]["X"].values())) == entities[i]["features"]["row_a"]
+        pd.DataFrame.from_dict(similar_entities[eid]["X"], orient="index")  # Assert no error
+        pd.Series(similar_entities[eid]["y"])  # Assert no error
+        pd.Series(similar_entities[eid]["Input"])  # Assert no error
 
     response = client.post(
         "/api/v1/similar_entities/",
@@ -194,7 +195,8 @@ def test_post_similar_entities(client, models, entities, multirow_entities):
         },
     ).json
     similar_entities = response["similar_entities"]
-    for eid in [entity["eid"] for entity in multirow_entities]:  # Assert no error
-        pd.DataFrame.from_dict(similar_entities[eid]["X"], orient="index")
-        pd.Series(similar_entities[eid]["y"])
-        pd.Series(similar_entities[eid]["Input"])
+    for i, eid in enumerate([entity["eid"] for entity in multirow_entities]):
+        assert next(iter(similar_entities[eid]["X"].values())) == entities[i]["features"]["row_b"]
+        pd.DataFrame.from_dict(similar_entities[eid]["X"], orient="index")  # Assert no error
+        pd.Series(similar_entities[eid]["y"])  # Assert no error
+        pd.Series(similar_entities[eid]["Input"])  # Assert no error


### PR DESCRIPTION
### Closing issues

Closes #83 

### Description

Updates `MultiContribution` and `SimilarEntities` to use a dictionary return instead of json string. The output still looks the same, but the format is more easily usable. This **does change** the outward facing json returns.

Code can be updated for this change by simply using `pd.DataFrame.from_dict(orient="index")` or `pd.Series()` instead of `from_json`.

### Test Plan

Unit tests have been updated, and improved to check that the correct row is being used.
