### PR TITLE
resolve bug when row_id is not given

### DIFF
--- a/sibyl/resources/computing.py
+++ b/sibyl/resources/computing.py
@@ -529,8 +529,10 @@ class SimilarEntities(Resource):
 
         attr_info = [Attrs("eids", type=None), Attrs("model_id"), Attrs("row_id", required=False)]
         eids, model_id, row_id = get_and_validate_params(attr_info)
-
-        entities = get_entities_table(eids, [row_id])
+        if row_id is None:
+            entities = get_entities_table(eids, row_id)
+        else:
+            entities = get_entities_table(eids, [row_id])
         success, payload = helpers.load_explainer(model_id, include_dataset=True)
         if success:
             explainer, dataset = payload


### PR DESCRIPTION
Currently, the Similar Cases page is broken due to a bug in the way row_id is used in the API implementation. This PR should resolve this bug.

