### PR TITLE
Removing windows mongodb testing

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -8,14 +8,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ["ubuntu-latest", "windows-latest"]
+        os: ["ubuntu-latest"]
         python-version: ["3.8", "3.9", "3.10"]
-        mongodb-version: ['5.0', '6.0']
-        exclude:
-          - os: "ubuntu-latest"
-            mongodb-version: "5.0"
-          - os: "windows-latest"
-            mongodb-version: "6.0"
+        mongodb-version: ['6.0', '7.0']
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25


### PR DESCRIPTION
The windows testing for mongodb has frequent errors with timing out that are affecting development time. I'm removing them for now, to be added back if a more consistent method can be found

